### PR TITLE
[update] ConfirmReservationDialogの終了ボタンを押してもダイアログが閉じなかったのを修正

### DIFF
--- a/src/client_system/ConfirmCancelReservationDialog.java
+++ b/src/client_system/ConfirmCancelReservationDialog.java
@@ -79,14 +79,14 @@ public class ConfirmCancelReservationDialog extends Dialog implements ActionList
 	@Override
 	public void windowClosing(WindowEvent e) {
 		// TODO 自動生成されたメソッド・スタブ
+		setVisible( false);
+		dispose();	
 		
 	}
 
 	@Override
 	public void windowClosed(WindowEvent e) {
 		// TODO 自動生成されたメソッド・スタブ
-		setVisible( false);
-		dispose();	
 		
 	}
 


### PR DESCRIPTION
ConfirmReservationDialogの終了ボタンを押下したときのウィンドウを消す動作が、別の場所にあったのを修正
- windowClosed()メソッド内にあった "setVisible( false);" と "dispose();" をwindowClosing()メソッド内に移した。